### PR TITLE
make login compatible with Technicolor CGA6444VF

### DIFF
--- a/src/modem/technicolor-modem.ts
+++ b/src/modem/technicolor-modem.ts
@@ -166,6 +166,12 @@ export class Technicolor extends Modem {
         },
       })
       this.logger.debug('Login status', loginResponse)
+      const {data: messageResponse} = await this.httpClient.get<TechnicolorBaseResponse>('/api/v1/session/menu', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        },
+      })
+      this.logger.debug('Message status', messageResponse)
     } catch (error) {
       this.logger.warn(`Something went wrong with the login ${error}`)
     }


### PR DESCRIPTION
The Vodafone Station CGA6444VF which is also produced by Technicolor needs an additional API Call before the user is authorized to pull any other data like the docsis status.

Please see this change as a first draft or suggestion.

I do not have access to a CGA4322DE and therefore do not know if the message API Endpoint does exist there or if it is necessary to call it there as well.
Maybe it was added in a recent firmware update, i just received the CGA6444VF with the firmware it is currently running.

If there needs to be another distinction between the two Technicolor Models we could probably grab the model name from the `login_conf`:
```json
{
    "error":"ok",
    "message":"all values retrieved",
    "data":{
        "LanMode":"bridge-static",
        "DeviceMode":"Bridge",
        "AFTR":"",
        "firmwareversion":"19.3B57-1.0.41",
        "internetipv4":"0.0.0.0",
        "ModelName":"CGA6444VF",
        "IPAddressRT":["0000::0000:0000:0000:0000\/","N\/A"]
    }
}
```