### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:16-alpine AS build
+WORKDIR /usr/src/app
+COPY . .
+RUN yarn && npm install vodafone-station-cli &&\
+      npm prune --production
+
+FROM alpine
+RUN apk add --no-cache nodejs
+WORKDIR /usr/src/app
+COPY --from=build /usr/src/app/node_modules ./node_modules
+ENTRYPOINT ["/usr/src/app/node_modules/vodafone-station-cli/bin/run"]


### PR DESCRIPTION
Creates a ~77 MB container that makes it easy to access this tool. E.g.:
`alias vodafone-station-cli="podman run --rm --secret VODAFONE_ROUTER_PASSWORD,type=env vodafone-station-cli:latest"`