### PR TITLE
Add commands for manipulating IPv6 host exposure settings on Arris modems

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,10 @@
     "commands": "./lib/commands",
     "plugins": [
       "@oclif/plugin-help"
-    ]
+    ],
+    "topics": {
+      "host-exposure": { "description": "Manage IPv6 host exposure settings." }
+    }
   },
   "scripts": {
     "build": "shx rm -rf lib && tsc -b",

--- a/src/commands/host-exposure/disable.ts
+++ b/src/commands/host-exposure/disable.ts
@@ -1,0 +1,51 @@
+import {Flags} from '@oclif/core'
+import Command from '../../base-command'
+import {toggleHostExposureEntries} from '../../modem/host-exposure';
+
+export default class DisableHostExposureEntries extends Command {
+  static description =
+    'Disable a set of host exposure entries';
+
+  static examples = [
+    `$ vodafone-station-cli host-exposure:disable -p PASSWORD [ENTRY NAME | [ENTRY NAME...]]`,
+  ];
+
+  static args = [
+    {
+      name: "entries",
+      description: 'Host exposure entries to disable. Pass no names to disable every existing entry.',
+      required: false,
+    }
+  ];
+
+  static flags = {
+    password: Flags.string({
+      char: 'p',
+      description: 'router/modem password',
+    }),
+  };
+
+  static strict = false
+
+  async run(): Promise<void> {
+    const {argv, flags} = await this.parse(DisableHostExposureEntries)
+
+    const password = flags.password ?? process.env.VODAFONE_ROUTER_PASSWORD
+    if (!password || password === '') {
+      this.log(
+        'You must provide a password either using -p or by setting the environment variable VODAFONE_ROUTER_PASSWORD'
+      )
+      this.exit()
+    }
+
+    try {
+      await toggleHostExposureEntries(false, argv as string[], password!, this.logger)
+    }
+    catch (error) {
+      this.error(error as Error, {message: 'Something went wrong.'})
+    }
+
+
+    this.exit()
+  }
+}

--- a/src/commands/host-exposure/enable.ts
+++ b/src/commands/host-exposure/enable.ts
@@ -1,0 +1,51 @@
+import {Flags} from '@oclif/core'
+import Command from '../../base-command'
+import {toggleHostExposureEntries} from '../../modem/host-exposure';
+
+export default class EnableHostExposureEntries extends Command {
+  static description =
+    'Enable a set of host exposure entries';
+
+  static examples = [
+    `$ vodafone-station-cli host-exposure:enable -p PASSWORD [ENTRY NAME | [ENTRY NAME...]]`,
+  ];
+
+  static args = [
+    {
+      name: "entries",
+      description: 'Host exposure entries to enable. Pass no names to enable every existing entry.',
+      required: false,
+    }
+  ];
+
+  static flags = {
+    password: Flags.string({
+      char: 'p',
+      description: 'router/modem password',
+    }),
+  };
+
+  static strict = false
+
+  async run(): Promise<void> {
+    const {argv, flags} = await this.parse(EnableHostExposureEntries)
+
+    const password = flags.password ?? process.env.VODAFONE_ROUTER_PASSWORD
+    if (!password || password === '') {
+      this.log(
+        'You must provide a password either using -p or by setting the environment variable VODAFONE_ROUTER_PASSWORD'
+      )
+      this.exit()
+    }
+
+    try {
+      await toggleHostExposureEntries(true, argv as string[], password!, this.logger)
+    }
+    catch (error) {
+      this.error(error as Error, {message: 'Something went wrong.'})
+    }
+
+
+    this.exit()
+  }
+}

--- a/src/commands/host-exposure/get.ts
+++ b/src/commands/host-exposure/get.ts
@@ -1,0 +1,64 @@
+import {Flags} from '@oclif/core'
+import Command from '../../base-command'
+import {discoverModemIp, ModemDiscovery} from '../../modem/discovery'
+import {modemFactory} from '../../modem/factory'
+import {Log} from '../../logger'
+import {HostExposureSettings} from '../../modem/modem';
+
+
+export async function getHostExposureSettings(password: string, logger: Log): Promise<HostExposureSettings> {
+  const modemIp = await discoverModemIp()
+  const discoveredModem = await new ModemDiscovery(modemIp, logger).discover()
+  const modem = modemFactory(discoveredModem, logger)
+  try {
+    await modem.login(password)
+    const settings = await modem.getHostExposure()
+    return settings
+  } catch (error) {
+    console.error('Could not get host exposure settings from modem.', error)
+    throw error
+  } finally {
+    await modem.logout()
+  }
+}
+
+export default class GetHostExposure extends Command {
+  static description =
+    'Get the current IPV6 host exposure settings';
+
+  static examples = [
+    `$ vodafone-station-cli host-exposure:get -p PASSWORD
+{JSON data}
+`,
+  ];
+
+  static flags = {
+    password: Flags.string({
+      char: 'p',
+      description: 'router/modem password',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(GetHostExposure)
+
+    const password = flags.password ?? process.env.VODAFONE_ROUTER_PASSWORD
+    if (!password || password === '') {
+      this.log(
+        'You must provide a password either using -p or by setting the environment variable VODAFONE_ROUTER_PASSWORD'
+      )
+      this.exit()
+    }
+    try {
+      const settings = await getHostExposureSettings(password!, this.logger)
+      const settingsJSON = JSON.stringify(settings, undefined, 4)
+      this.log(settingsJSON)
+    }
+    catch (error) {
+      this.error(error as Error, {message: 'Something went wrong.'})
+    }
+
+
+    this.exit()
+  }
+}

--- a/src/commands/host-exposure/set.ts
+++ b/src/commands/host-exposure/set.ts
@@ -1,0 +1,72 @@
+import {readFile} from 'node:fs/promises'
+import {Flags} from '@oclif/core'
+import Command from '../../base-command'
+import {discoverModemIp, ModemDiscovery} from '../../modem/discovery'
+import {modemFactory} from '../../modem/factory'
+import {Log} from '../../logger'
+import {HostExposureSettings} from '../../modem/modem';
+
+
+export async function setHostExposureSettings(settings: HostExposureSettings, password: string, logger: Log): Promise<HostExposureSettings> {
+  const modemIp = await discoverModemIp()
+  const discoveredModem = await new ModemDiscovery(modemIp, logger).discover()
+  const modem = modemFactory(discoveredModem, logger)
+  try {
+    await modem.login(password)
+    await modem.setHostExposure(settings)
+    return settings
+  } catch (error) {
+    logger.error('Could not get host exposure settings from modem.', error)
+    throw error
+  } finally {
+    await modem.logout()
+  }
+}
+
+export default class SetHostExposure extends Command {
+  static description =
+    'Set the current IPV6 host exposure settings from a JSON file';
+
+  static examples = [
+    `$ vodafone-station-cli host-exposure:set -p PASSWORD <FILE>`,
+  ];
+
+  static args = [
+    {
+      name: "file",
+      description: "input JSON file",
+      required: true,
+    }
+  ];
+
+  static flags = {
+    password: Flags.string({
+      char: 'p',
+      description: 'router/modem password',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(SetHostExposure)
+
+    const password = flags.password ?? process.env.VODAFONE_ROUTER_PASSWORD
+    if (!password || password === '') {
+      this.log(
+        'You must provide a password either using -p or by setting the environment variable VODAFONE_ROUTER_PASSWORD'
+      )
+      this.exit()
+    }
+    try {
+      const newSettingsJSON = await readFile(args.file, {encoding: 'utf8'})
+      const newSettings = JSON.parse(newSettingsJSON) as HostExposureSettings
+      await setHostExposureSettings(newSettings, password!, this.logger)
+      this.log("New host exposure settings set.")
+    }
+    catch (error) {
+      this.error(error as Error, {message: 'Something went wrong.'})
+    }
+
+
+    this.exit()
+  }
+}

--- a/src/modem/arris-modem.ts
+++ b/src/modem/arris-modem.ts
@@ -22,21 +22,6 @@ export interface ArrisDocsisChannelStatus {
   LockStatus: string;
 }
 
-export interface ArrisHostExposureSettings {
-  hostExposure: ArrisExposedHostSettings[];
-  dhcpclient: any;
-}
-
-export interface ArrisExposedHostSettings {
-  ServiceName: string;
-  MAC: string;
-  Protocol: Protocol;
-  StartPort: number;
-  EndPort: number;
-  Status: string;
-  Index: string;
-}
-
 export interface SetPasswordRequest {
   AuthData: string;
   EncryptData: string;
@@ -47,6 +32,35 @@ export interface SetPasswordResponse {
   p_status: string;
   encryptData: string;
   p_waitTime?: number;
+}
+
+interface ArrisGetHostExposureSettings {
+  hostExposure: ArrisGetExposedHostSettings[];
+  dhcpclient: any;
+}
+
+interface ArrisGetExposedHostSettings {
+  ServiceName: string;
+  MAC: string;
+  Protocol: Protocol;
+  StartPort: number;
+  EndPort: number;
+  Status: string;
+  Index: string;
+}
+
+interface ArrisSetHostExposureSettings {
+  hEditRule: ArrisSetExposedHostSettings[];
+}
+
+interface ArrisSetExposedHostSettings {
+  name: string;
+  macAddress: string;
+  protocol: Protocol;
+  startPort: number;
+  endPort: number;
+  enable: string;
+  index: string;
 }
 
 export function normalizeChannelStatus(channelStatus: ArrisDocsisChannelStatus): HumanizedDocsisChannelStatus | HumanizedDocsis31ChannelStatus {
@@ -60,7 +74,7 @@ export function normalizeChannelStatus(channelStatus: ArrisDocsisChannelStatus):
     frequency.frequencyStart = Number(ofdmaFrequency[0])
     frequency.frequencyEnd = Number(ofdmaFrequency[1])
   }
-  
+
   const powerLevel = parseFloat(channelStatus.PowerLevel.split("/")[0]);
   const snr = parseInt(`${channelStatus.SNRLevel ?? 0}`, 10);
   return {
@@ -253,7 +267,7 @@ export class Arris extends Modem {
     }
   }
 
-  convertExposedHostSettings(settings: ArrisExposedHostSettings): ExposedHostSettings {
+  _convertGetExposedHostSettings(settings: ArrisGetExposedHostSettings): ExposedHostSettings {
     return {
       serviceName: settings.ServiceName,
       mac: settings.MAC,
@@ -277,10 +291,47 @@ export class Arris extends Modem {
           },
         }
       )
-      return {hosts: data.hostExposure.map(this.convertExposedHostSettings)} as HostExposureSettings
+      return {
+        hosts: (data as ArrisGetHostExposureSettings)
+          .hostExposure.map(this._convertGetExposedHostSettings)
+      } as HostExposureSettings
     }
     catch (error) {
       this.logger.error("Could not get host exposure data:\n", error)
+      throw error
+    }
+  }
+
+  _convertSetExposedHostSettings(settings: ExposedHostSettings): ArrisSetExposedHostSettings {
+    return {
+      name: settings.serviceName,
+      macAddress: settings.mac,
+      protocol: settings.protocol,
+      startPort: settings.startPort,
+      endPort: settings.endPort,
+      enable: settings.enabled ? "Enabled" : "Disabled",
+      index: settings.index.toString(),
+    }
+  }
+
+  async setHostExposure(settings: HostExposureSettings): Promise<void> {
+    const convertedSettings =
+      {hEditRule: settings.hosts.map(this._convertSetExposedHostSettings)} as ArrisSetHostExposureSettings
+    try {
+      await this.httpClient.post(
+        'php/ajaxSet_net_ipv6_host_exposure_data.php',
+        convertedSettings,
+        {
+          headers: {
+            csrfNonce: this.csrfNonce,
+            Referer: `http://${this.modemIp}/?net_ipv6_host_exposure&mid=NetIPv6HostExposure`,
+            Connection: 'keep-alive',
+          }
+        }
+      )
+    }
+    catch (error) {
+      console.error("Could not set host exposure data:\n", error)
       throw error
     }
   }

--- a/src/modem/host-exposure.ts
+++ b/src/modem/host-exposure.ts
@@ -1,0 +1,34 @@
+import {discoverModemIp, ModemDiscovery} from './discovery'
+import {modemFactory} from './factory'
+import {Log} from '../logger'
+
+export async function toggleHostExposureEntries(toggle: boolean, entries: string[], password: string, logger: Log): Promise<void> {
+  const modemIp = await discoverModemIp()
+  const discoveredModem = await new ModemDiscovery(modemIp, logger).discover()
+  const modem = modemFactory(discoveredModem, logger)
+  try {
+    await modem.login(password)
+    let settings = await modem.getHostExposure()
+
+    let names = entries
+    if (names.length === 0) {
+      names = settings.hosts.map((host) => host.serviceName)
+    }
+
+    for (const name of names) {
+      const index = settings.hosts.findIndex((host) => host.serviceName === name)
+      if (index === -1) {
+        logger.warn(`Entry with the name '${name}' does not exist.`)
+      } else {
+        settings.hosts[index].enabled = toggle
+      }
+    }
+
+    await modem.setHostExposure(settings)
+  } catch (error) {
+    logger.error('Could not change host exposure settings on modem.', error)
+    throw error
+  } finally {
+    await modem.logout()
+  }
+}

--- a/src/modem/modem.ts
+++ b/src/modem/modem.ts
@@ -104,6 +104,10 @@ export abstract class Modem implements GenericModem {
     throw new Error('Method not implemented.')
   }
 
+  setHostExposure(_: HostExposureSettings): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+
   private initAxios(): AxiosInstance {
     return wrapper(axios.create({
       withCredentials: true,

--- a/src/modem/modem.ts
+++ b/src/modem/modem.ts
@@ -7,6 +7,8 @@ export type DocsisChannelType = 'OFDM' | 'OFDMA' | 'SC-QAM'
 
 export type Modulation = "16QAM" | "64QAM" | "256QAM" | "1024QAM" | "2048QAM" | "4096QAM"
 
+export type Protocol = "TCP" | "UDP"
+
 export interface HumanizedDocsisChannelStatus {
   channelId: string;
   channelType: DocsisChannelType;
@@ -51,11 +53,26 @@ export interface DiagnosedDocsisStatus {
   time: string;
 }
 
+export interface ExposedHostSettings {
+  serviceName: string;
+  mac: string;
+  protocol: Protocol;
+  startPort: number;
+  endPort: number;
+  enabled: boolean;
+  index: number;
+}
+
+export interface HostExposureSettings {
+  hosts: ExposedHostSettings[];
+}
+
 export interface GenericModem {
   logout(): Promise<void>;
   login(password: string): Promise<void>;
   docsis(): Promise<DocsisStatus>;
   restart(): Promise<unknown>;
+  getHostExposure(): Promise<HostExposureSettings>;
 }
 
 export abstract class Modem implements GenericModem {
@@ -80,6 +97,10 @@ export abstract class Modem implements GenericModem {
   }
 
   logout(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+
+  getHostExposure(): Promise<HostExposureSettings> {
     throw new Error('Method not implemented.')
   }
 


### PR DESCRIPTION
This PR aims to add a new feature: Four commands for working with the IPv6 host exposure settings available on Arris modems. They are:
- `host-exposure:get`: Gets the current host exposure settings as JSON
- `host-exposure:set <FILE>`: Set the host exposure settings on the modem from a file with JSON in the same format as produced by the `get` command
- `host-exposure:(en|dis)able [ENTRY 1 | [ENTRY 2...] ]`: Enable or disable all or specific entries in the host exposure settings by name of the entries

I have implemented these commands since they are useful in managing my infrastructure, in the hope that they'll be useful to others as well.
Unfortunately, I cannot provide an implementation for Technicolor modems since I don't own one to reverse-engineer the necessary settings with (if those are even available on Technicolor modems in the first place). If someone provides information on how Technicolor modems implement host exposure, I could add a corresponding implementation.