### PR TITLE
feat: add manual IP setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ $ npm install -g vodafone-station-cli
 $ vodafone-station-cli COMMAND
 running command...
 $ vodafone-station-cli (--version)
-vodafone-station-cli/1.4.0 darwin-arm64 node-v23.7.0
+vodafone-station-cli/1.5.0 darwin-arm64 node-v23.7.0
 $ vodafone-station-cli --help [COMMAND]
 USAGE
   $ vodafone-station-cli COMMAND
@@ -557,7 +557,7 @@ USAGE
 * [`vodafone-station-cli docsis`](#vodafone-station-cli-docsis)
 * [`vodafone-station-cli help [COMMAND]`](#vodafone-station-cli-help-command)
 * [`vodafone-station-cli host-exposure disable [ENTRIES]`](#vodafone-station-cli-host-exposure-disable-entries)
-* [`vodafone-station-cli host-exposure enable [ENTRIES]`](#vodafone-station-cli-host-exposure-enable-entries)
+* [`vodafone-station-cli host-exposure enable`](#vodafone-station-cli-host-exposure-enable)
 * [`vodafone-station-cli host-exposure get`](#vodafone-station-cli-host-exposure-get)
 * [`vodafone-station-cli host-exposure set FILE`](#vodafone-station-cli-host-exposure-set-file)
 * [`vodafone-station-cli plugins`](#vodafone-station-cli-plugins)
@@ -578,9 +578,10 @@ Diagnose the quality of the docsis connection.
 
 ```
 USAGE
-  $ vodafone-station-cli diagnose [-p <value>] [-w]
+  $ vodafone-station-cli diagnose [-i <value>] [-p <value>] [-w]
 
 FLAGS
+  -i, --ip=<value>        IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)
   -p, --password=<value>  router/modem password
   -w, --web               review the docsis values in a webapp
 
@@ -589,9 +590,11 @@ DESCRIPTION
 
 EXAMPLES
   $ vodafone-station-cli diagnose
+
+  $ vodafone-station-cli diagnose --ip 192.168.100.1
 ```
 
-_See code: [src/commands/diagnose.ts](https://github.com/totev/vodafone-station-cli/blob/v1.4.0/src/commands/diagnose.ts)_
+_See code: [src/commands/diagnose.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/diagnose.ts)_
 
 ## `vodafone-station-cli discover`
 
@@ -599,16 +602,21 @@ Try to discover a cable modem in the network
 
 ```
 USAGE
-  $ vodafone-station-cli discover
+  $ vodafone-station-cli discover [-i <value>]
+
+FLAGS
+  -i, --ip=<value>  IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)
 
 DESCRIPTION
   Try to discover a cable modem in the network
 
 EXAMPLES
   $ vodafone-station-cli discover
+
+  $ vodafone-station-cli discover --ip 192.168.100.1
 ```
 
-_See code: [src/commands/discover.ts](https://github.com/totev/vodafone-station-cli/blob/v1.4.0/src/commands/discover.ts)_
+_See code: [src/commands/discover.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/discover.ts)_
 
 ## `vodafone-station-cli docsis`
 
@@ -616,10 +624,11 @@ Get the current docsis status as reported by the modem in a JSON format.
 
 ```
 USAGE
-  $ vodafone-station-cli docsis [-f] [-p <value>] [-w]
+  $ vodafone-station-cli docsis [-i <value>] [-f] [-p <value>] [-w]
 
 FLAGS
   -f, --file              write out a report file under ./reports/{CURRENT_UNIX_TIMESTAMP}_docsisStatus.json
+  -i, --ip=<value>        IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)
   -p, --password=<value>  router/modem password
   -w, --web               review the docsis values in a webapp
 
@@ -629,9 +638,12 @@ DESCRIPTION
 EXAMPLES
   $ vodafone-station-cli docsis -p PASSWORD
   {JSON data}
+
+  $ vodafone-station-cli docsis -p PASSWORD --ip 192.168.100.1
+  {JSON data}
 ```
 
-_See code: [src/commands/docsis.ts](https://github.com/totev/vodafone-station-cli/blob/v1.4.0/src/commands/docsis.ts)_
+_See code: [src/commands/docsis.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/docsis.ts)_
 
 ## `vodafone-station-cli help [COMMAND]`
 
@@ -659,12 +671,13 @@ Disable a set of host exposure entries
 
 ```
 USAGE
-  $ vodafone-station-cli host-exposure disable [ENTRIES...] [-p <value>]
+  $ vodafone-station-cli host-exposure disable [ENTRIES...] [-i <value>] [-p <value>]
 
 ARGUMENTS
   ENTRIES...  Host exposure entries to disable. Pass no names to disable every existing entry.
 
 FLAGS
+  -i, --ip=<value>        IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)
   -p, --password=<value>  router/modem password
 
 DESCRIPTION
@@ -672,22 +685,22 @@ DESCRIPTION
 
 EXAMPLES
   $ vodafone-station-cli host-exposure:disable -p PASSWORD [ENTRY NAME | [ENTRY NAME...]]
+
+  $ vodafone-station-cli host-exposure:disable -p PASSWORD --ip 192.168.100.1 [ENTRY NAME | [ENTRY NAME...]]
 ```
 
-_See code: [src/commands/host-exposure/disable.ts](https://github.com/totev/vodafone-station-cli/blob/v1.4.0/src/commands/host-exposure/disable.ts)_
+_See code: [src/commands/host-exposure/disable.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/host-exposure/disable.ts)_
 
-## `vodafone-station-cli host-exposure enable [ENTRIES]`
+## `vodafone-station-cli host-exposure enable`
 
 Enable a set of host exposure entries
 
 ```
 USAGE
-  $ vodafone-station-cli host-exposure enable [ENTRIES...] [-p <value>]
-
-ARGUMENTS
-  ENTRIES...  Host exposure entries to enable. Pass no names to enable every existing entry.
+  $ vodafone-station-cli host-exposure enable [-i <value>] [-p <value>]
 
 FLAGS
+  -i, --ip=<value>        IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)
   -p, --password=<value>  router/modem password
 
 DESCRIPTION
@@ -695,9 +708,11 @@ DESCRIPTION
 
 EXAMPLES
   $ vodafone-station-cli host-exposure:enable -p PASSWORD [ENTRY NAME | [ENTRY NAME...]]
+
+  $ vodafone-station-cli host-exposure:enable -p PASSWORD --ip 192.168.100.1 [ENTRY NAME | [ENTRY NAME...]]
 ```
 
-_See code: [src/commands/host-exposure/enable.ts](https://github.com/totev/vodafone-station-cli/blob/v1.4.0/src/commands/host-exposure/enable.ts)_
+_See code: [src/commands/host-exposure/enable.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/host-exposure/enable.ts)_
 
 ## `vodafone-station-cli host-exposure get`
 
@@ -705,9 +720,10 @@ Get the current IPV6 host exposure settings
 
 ```
 USAGE
-  $ vodafone-station-cli host-exposure get [-p <value>]
+  $ vodafone-station-cli host-exposure get [-i <value>] [-p <value>]
 
 FLAGS
+  -i, --ip=<value>        IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)
   -p, --password=<value>  router/modem password
 
 DESCRIPTION
@@ -716,9 +732,12 @@ DESCRIPTION
 EXAMPLES
   $ vodafone-station-cli host-exposure:get -p PASSWORD
   {JSON data}
+
+  $ vodafone-station-cli host-exposure:get -p PASSWORD --ip 192.168.100.1
+  {JSON data}
 ```
 
-_See code: [src/commands/host-exposure/get.ts](https://github.com/totev/vodafone-station-cli/blob/v1.4.0/src/commands/host-exposure/get.ts)_
+_See code: [src/commands/host-exposure/get.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/host-exposure/get.ts)_
 
 ## `vodafone-station-cli host-exposure set FILE`
 
@@ -726,12 +745,13 @@ Set the current IPV6 host exposure settings from a JSON file
 
 ```
 USAGE
-  $ vodafone-station-cli host-exposure set FILE [-p <value>]
+  $ vodafone-station-cli host-exposure set FILE [-i <value>] [-p <value>]
 
 ARGUMENTS
   FILE  input JSON file
 
 FLAGS
+  -i, --ip=<value>        IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)
   -p, --password=<value>  router/modem password
 
 DESCRIPTION
@@ -739,9 +759,11 @@ DESCRIPTION
 
 EXAMPLES
   $ vodafone-station-cli host-exposure:set -p PASSWORD <FILE>
+
+  $ vodafone-station-cli host-exposure:set -p PASSWORD --ip 192.168.100.1 <FILE>
 ```
 
-_See code: [src/commands/host-exposure/set.ts](https://github.com/totev/vodafone-station-cli/blob/v1.4.0/src/commands/host-exposure/set.ts)_
+_See code: [src/commands/host-exposure/set.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/host-exposure/set.ts)_
 
 ## `vodafone-station-cli plugins`
 
@@ -1035,21 +1057,24 @@ _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/
 
 ## `vodafone-station-cli restart`
 
-Restart the router/modem
+restart the modem/router
 
 ```
 USAGE
-  $ vodafone-station-cli restart [-p <value>]
+  $ vodafone-station-cli restart [-i <value>] [-p <value>]
 
 FLAGS
+  -i, --ip=<value>        IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)
   -p, --password=<value>  router/modem password
 
 DESCRIPTION
-  Restart the router/modem
+  restart the modem/router
 
 EXAMPLES
-  $ vodafone-station-cli restart -p PASSWORD
+  $ vodafone-station-cli restart
+
+  $ vodafone-station-cli restart --ip 192.168.100.1
 ```
 
-_See code: [src/commands/restart.ts](https://github.com/totev/vodafone-station-cli/blob/v1.4.0/src/commands/restart.ts)_
+_See code: [src/commands/restart.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/restart.ts)_
 <!-- commandsstop -->

--- a/bin/dev
+++ b/bin/dev
@@ -8,7 +8,14 @@ const project = path.join(__dirname, '..', 'tsconfig.json')
 // In dev mode -> use ts-node and dev plugins
 process.env.NODE_ENV = 'development'
 
-require('ts-node').register({project})
+// Clear ts-node's cache to ensure using the latest code
+require('ts-node').register({
+  project,
+  transpileOnly: true,
+  compilerOptions: {
+    module: 'commonjs'
+  }
+})
 
 // In dev mode, always show stack traces
 oclif.settings.debug = true;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vodafone-station-cli",
   "description": "Access your Vodafone Station from the comfort of the command line.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": "Dobroslav Totev",
   "bin": {
     "vodafone-station-cli": "./bin/run"

--- a/src/base-command.test.ts
+++ b/src/base-command.test.ts
@@ -1,4 +1,3 @@
-import { Flags } from '@oclif/core';
 import { ipFlag } from './base-command';
 
 describe('Base Command', () => {

--- a/src/base-command.test.ts
+++ b/src/base-command.test.ts
@@ -1,0 +1,23 @@
+import { Flags } from '@oclif/core';
+import { ipFlag } from './base-command';
+
+describe('Base Command', () => {
+  describe('ipFlag', () => {
+    it('should create an IP flag with correct properties', () => {
+      const flag = ipFlag();
+      
+      expect(flag).toBeDefined();
+      expect(flag.char).toBe('i');
+      expect(flag.description).toBe('IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)');
+      expect(flag.required).toBeUndefined();
+    });
+
+    it('should be compatible with OCLIF flags', () => {
+      const flags = {
+        ip: ipFlag()
+      };
+      
+      expect(flags.ip).toBeDefined();
+    });
+  });
+}); 

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -6,9 +6,8 @@ config()
 
 export const ipFlag = () => Flags.string({
   char: 'i',
-  description: 'IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1).',
+  description: 'IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)',
   env: 'VODAFONE_ROUTER_IP',
-  multiple: false,
 })
 
 export default abstract class BaseCommand extends Command {

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -1,8 +1,14 @@
-import {Command} from '@oclif/core'
-import {config} from 'dotenv'
+import { Command, Flags } from '@oclif/core'
+import { config } from 'dotenv'
 
-import {Log, OclifLogger} from './logger'
+import { Log, OclifLogger } from './logger'
 config()
+
+export const ipFlag = () => Flags.string({
+  char: 'i',
+  description: 'IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)',
+  env: 'VODAFONE_ROUTER_IP',
+})
 
 export default abstract class BaseCommand extends Command {
   get logger(): Log {

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -6,8 +6,9 @@ config()
 
 export const ipFlag = () => Flags.string({
   char: 'i',
-  description: 'IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1)',
+  description: 'IP address of the modem/router (default: try 192.168.100.1 and 192.168.0.1).',
   env: 'VODAFONE_ROUTER_IP',
+  multiple: false,
 })
 
 export default abstract class BaseCommand extends Command {

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -1,7 +1,7 @@
-import { Command, Flags } from '@oclif/core'
-import { config } from 'dotenv'
+import {Command, Flags} from '@oclif/core'
+import {config} from 'dotenv'
 
-import { Log, OclifLogger } from './logger'
+import {Log, OclifLogger} from './logger'
 config()
 
 export const ipFlag = () => Flags.string({

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -1,11 +1,11 @@
-import { Flags } from '@oclif/core';
+import {Flags} from '@oclif/core';
 
-import Command, { ipFlag } from '../base-command';
-import { DiscoveryOptions } from '../modem/discovery';
+import Command, {ipFlag} from '../base-command';
+import {DiscoveryOptions} from '../modem/discovery';
 import DocsisDiagnose from '../modem/docsis-diagnose';
-import { TablePrinter } from '../modem/printer';
-import { webDiagnoseLink } from '../modem/web-diagnose';
-import { getDocsisStatus } from './docsis';
+import {TablePrinter} from '../modem/printer';
+import {webDiagnoseLink} from '../modem/web-diagnose';
+import {getDocsisStatus} from './docsis';
 
 export default class Diagnose extends Command {
   static description

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -1,18 +1,21 @@
-import {Flags} from '@oclif/core';
+import { Flags } from '@oclif/core';
 
-import Command from '../base-command';
+import Command, { ipFlag } from '../base-command';
+import { DiscoveryOptions } from '../modem/discovery';
 import DocsisDiagnose from '../modem/docsis-diagnose';
-import {TablePrinter} from '../modem/printer';
-import {webDiagnoseLink} from '../modem/web-diagnose';
-import {getDocsisStatus} from './docsis';
+import { TablePrinter } from '../modem/printer';
+import { webDiagnoseLink } from '../modem/web-diagnose';
+import { getDocsisStatus } from './docsis';
 
 export default class Diagnose extends Command {
   static description
     = 'Diagnose the quality of the docsis connection.';
   static examples = [
     '$ vodafone-station-cli diagnose',
+    '$ vodafone-station-cli diagnose --ip 192.168.100.1',
   ];
   static flags = {
+    ip: ipFlag(),
     password: Flags.string({
       char: 'p',
       description: 'router/modem password',
@@ -32,8 +35,12 @@ export default class Diagnose extends Command {
       this.exit()
     }
 
+    const discoveryOptions: DiscoveryOptions = {
+      ip: flags.ip,
+    }
+
     try {
-      const docsisStatus = await getDocsisStatus(password!, this.logger)
+      const docsisStatus = await getDocsisStatus(password!, this.logger, discoveryOptions)
       const diagnoser = new DocsisDiagnose(docsisStatus)
       const tablePrinter = new TablePrinter(docsisStatus);
       this.log(tablePrinter.print())

--- a/src/commands/discover.ts
+++ b/src/commands/discover.ts
@@ -1,5 +1,5 @@
-import Command, { ipFlag } from '../base-command';
-import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../modem/discovery';
+import Command, {ipFlag} from '../base-command';
+import {discoverModemLocation, DiscoveryOptions, ModemDiscovery} from '../modem/discovery';
 
 export default class Discover extends Command {
   static description
@@ -8,7 +8,6 @@ export default class Discover extends Command {
     '$ vodafone-station-cli discover',
     '$ vodafone-station-cli discover --ip 192.168.100.1',
   ];
-
   static flags = {
     ip: ipFlag(),
   }
@@ -19,7 +18,7 @@ export default class Discover extends Command {
       const discoveryOptions: DiscoveryOptions = {
         ip: flags.ip,
       }
-      
+
       const modemLocation = await discoverModemLocation(discoveryOptions);
       this.log(`Possibly found modem under the following location: ${JSON.stringify(modemLocation)}`);
       const modem = new ModemDiscovery(modemLocation, this.logger);

--- a/src/commands/discover.ts
+++ b/src/commands/discover.ts
@@ -1,16 +1,26 @@
-import Command from '../base-command';
-import {discoverModemLocation, ModemDiscovery} from '../modem/discovery';
+import Command, { ipFlag } from '../base-command';
+import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../modem/discovery';
 
 export default class Discover extends Command {
   static description
     = 'Try to discover a cable modem in the network';
   static examples = [
     '$ vodafone-station-cli discover',
+    '$ vodafone-station-cli discover --ip 192.168.100.1',
   ];
+
+  static flags = {
+    ip: ipFlag(),
+  }
 
   async discoverModem(): Promise<void> {
     try {
-      const modemLocation = await discoverModemLocation();
+      const {flags} = await this.parse(Discover)
+      const discoveryOptions: DiscoveryOptions = {
+        ip: flags.ip,
+      }
+      
+      const modemLocation = await discoverModemLocation(discoveryOptions);
       this.log(`Possibly found modem under the following location: ${JSON.stringify(modemLocation)}`);
       const modem = new ModemDiscovery(modemLocation, this.logger);
       const discoveredModem = await modem.discover();

--- a/src/commands/docsis.test.ts
+++ b/src/commands/docsis.test.ts
@@ -1,0 +1,154 @@
+import { discoverModemLocation, ModemDiscovery } from '../modem/discovery';
+import { modemFactory } from '../modem/factory';
+import { getDocsisStatus } from './docsis';
+
+// Mock all dependencies
+jest.mock('../modem/discovery');
+jest.mock('../modem/factory');
+
+const mockLogger = {
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+const mockModem = {
+  login: jest.fn(),
+  logout: jest.fn(),
+  docsis: jest.fn(),
+};
+
+describe('Docsis Command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getDocsisStatus', () => {
+    it('should pass IP parameter to discovery', async () => {
+      const mockModemLocation = { ipAddress: '192.168.1.100', protocol: 'http' as const };
+      const mockModemInfo = { 
+        deviceType: 'Technicolor' as const, 
+        firmwareVersion: '1.0', 
+        ipAddress: '192.168.1.100', 
+        protocol: 'http' as const 
+      };
+      const mockDocsisData = { 
+        downstream: [], 
+        upstream: [], 
+        uptime: '1 day' 
+      };
+
+      (discoverModemLocation as jest.Mock).mockResolvedValue(mockModemLocation);
+      (ModemDiscovery.prototype.discover as jest.Mock).mockResolvedValue(mockModemInfo);
+      (modemFactory as jest.Mock).mockReturnValue(mockModem);
+      mockModem.login.mockResolvedValue(undefined);
+      mockModem.docsis.mockResolvedValue(mockDocsisData);
+
+      const result = await getDocsisStatus('password', mockLogger as any, { ip: '192.168.1.100' });
+
+      expect(discoverModemLocation).toHaveBeenCalledWith({ ip: '192.168.1.100' });
+      expect(result).toBe(mockDocsisData);
+    });
+
+    it('should work without IP parameter (use defaults)', async () => {
+      const mockModemLocation = { ipAddress: '192.168.100.1', protocol: 'http' as const };
+      const mockModemInfo = { 
+        deviceType: 'Technicolor' as const, 
+        firmwareVersion: '1.0', 
+        ipAddress: '192.168.100.1', 
+        protocol: 'http' as const 
+      };
+      const mockDocsisData = { 
+        downstream: [], 
+        upstream: [], 
+        uptime: '1 day' 
+      };
+
+      (discoverModemLocation as jest.Mock).mockResolvedValue(mockModemLocation);
+      (ModemDiscovery.prototype.discover as jest.Mock).mockResolvedValue(mockModemInfo);
+      (modemFactory as jest.Mock).mockReturnValue(mockModem);
+      mockModem.login.mockResolvedValue(undefined);
+      mockModem.docsis.mockResolvedValue(mockDocsisData);
+
+      const result = await getDocsisStatus('password', mockLogger as any);
+
+      expect(discoverModemLocation).toHaveBeenCalledWith(undefined);
+      expect(result).toBe(mockDocsisData);
+    });
+
+    it('should handle modem login failure', async () => {
+      const mockModemLocation = { ipAddress: '192.168.1.100', protocol: 'http' as const };
+      const mockModemInfo = { 
+        deviceType: 'Technicolor' as const, 
+        firmwareVersion: '1.0', 
+        ipAddress: '192.168.1.100', 
+        protocol: 'http' as const 
+      };
+
+      (discoverModemLocation as jest.Mock).mockResolvedValue(mockModemLocation);
+      (ModemDiscovery.prototype.discover as jest.Mock).mockResolvedValue(mockModemInfo);
+      (modemFactory as jest.Mock).mockReturnValue(mockModem);
+      mockModem.login.mockRejectedValue(new Error('Login failed'));
+
+      await expect(getDocsisStatus('password', mockLogger as any, { ip: '192.168.1.100' }))
+        .rejects.toThrow('Login failed');
+
+      expect(mockModem.logout).toHaveBeenCalled();
+    });
+
+    it('should handle discovery failure', async () => {
+      (discoverModemLocation as jest.Mock).mockRejectedValue(new Error('Discovery failed'));
+
+      await expect(getDocsisStatus('password', mockLogger as any, { ip: '192.168.1.100' }))
+        .rejects.toThrow('Discovery failed');
+    });
+
+    it('should handle docsis fetch failure', async () => {
+      const mockModemLocation = { ipAddress: '192.168.1.100', protocol: 'http' as const };
+      const mockModemInfo = { 
+        deviceType: 'Technicolor' as const, 
+        firmwareVersion: '1.0', 
+        ipAddress: '192.168.1.100', 
+        protocol: 'http' as const 
+      };
+
+      (discoverModemLocation as jest.Mock).mockResolvedValue(mockModemLocation);
+      (ModemDiscovery.prototype.discover as jest.Mock).mockResolvedValue(mockModemInfo);
+      (modemFactory as jest.Mock).mockReturnValue(mockModem);
+      mockModem.login.mockResolvedValue(undefined);
+      mockModem.docsis.mockRejectedValue(new Error('Docsis fetch failed'));
+
+      await expect(getDocsisStatus('password', mockLogger as any, { ip: '192.168.1.100' }))
+        .rejects.toThrow('Docsis fetch failed');
+
+      expect(mockModem.logout).toHaveBeenCalled();
+    });
+
+    it('should always call logout even on success', async () => {
+      const mockModemLocation = { ipAddress: '192.168.1.100', protocol: 'http' as const };
+      const mockModemInfo = { 
+        deviceType: 'Technicolor' as const, 
+        firmwareVersion: '1.0', 
+        ipAddress: '192.168.1.100', 
+        protocol: 'http' as const 
+      };
+      const mockDocsisData = { 
+        downstream: [], 
+        upstream: [], 
+        uptime: '1 day' 
+      };
+
+      (discoverModemLocation as jest.Mock).mockResolvedValue(mockModemLocation);
+      (ModemDiscovery.prototype.discover as jest.Mock).mockResolvedValue(mockModemInfo);
+      (modemFactory as jest.Mock).mockReturnValue(mockModem);
+      mockModem.login.mockResolvedValue(undefined);
+      mockModem.docsis.mockResolvedValue(mockDocsisData);
+
+      await getDocsisStatus('password', mockLogger as any, { ip: '192.168.1.100' });
+
+      expect(mockModem.login).toHaveBeenCalledWith('password');
+      expect(mockModem.docsis).toHaveBeenCalled();
+      expect(mockModem.logout).toHaveBeenCalled();
+    });
+  });
+}); 

--- a/src/commands/docsis.ts
+++ b/src/commands/docsis.ts
@@ -1,12 +1,12 @@
-import { Flags } from '@oclif/core'
-import { promises as fsp } from 'node:fs'
+import {Flags} from '@oclif/core'
+import {promises as fsp} from 'node:fs'
 
-import Command, { ipFlag } from '../base-command'
-import { Log } from '../logger'
-import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../modem/discovery'
-import { modemFactory } from '../modem/factory'
-import { DocsisStatus } from '../modem/modem'
-import { webDiagnoseLink } from '../modem/web-diagnose'
+import Command, {ipFlag} from '../base-command'
+import {Log} from '../logger'
+import {discoverModemLocation, DiscoveryOptions, ModemDiscovery} from '../modem/discovery'
+import {modemFactory} from '../modem/factory'
+import {DocsisStatus} from '../modem/modem'
+import {webDiagnoseLink} from '../modem/web-diagnose'
 
 export async function getDocsisStatus(password: string, logger: Log, discoveryOptions?: DiscoveryOptions): Promise<DocsisStatus> {
   const modemLocation = await discoverModemLocation(discoveryOptions)
@@ -36,11 +36,11 @@ export default class Docsis extends Command {
 `,
   ]
   static flags = {
-    ip: ipFlag(),
     file: Flags.boolean({
       char: 'f',
       description: 'write out a report file under ./reports/{CURRENT_UNIX_TIMESTAMP}_docsisStatus.json',
     }),
+    ip: ipFlag(),
     password: Flags.string({
       char: 'p',
       description: 'router/modem password',

--- a/src/commands/host-exposure/disable.ts
+++ b/src/commands/host-exposure/disable.ts
@@ -1,8 +1,8 @@
-import { Args, Flags } from '@oclif/core'
+import {Args, Flags} from '@oclif/core'
 
-import Command, { ipFlag } from '../../base-command'
-import { DiscoveryOptions } from '../../modem/discovery'
-import { toggleHostExposureEntries } from '../../modem/host-exposure'
+import Command, {ipFlag} from '../../base-command'
+import {DiscoveryOptions} from '../../modem/discovery'
+import {toggleHostExposureEntries} from '../../modem/host-exposure'
 
 export default class DisableHostExposureEntries extends Command {
   static args = {

--- a/src/commands/host-exposure/disable.ts
+++ b/src/commands/host-exposure/disable.ts
@@ -1,7 +1,8 @@
-import {Args, Flags} from '@oclif/core'
+import { Args, Flags } from '@oclif/core'
 
-import Command from '../../base-command'
-import {toggleHostExposureEntries} from '../../modem/host-exposure'
+import Command, { ipFlag } from '../../base-command'
+import { DiscoveryOptions } from '../../modem/discovery'
+import { toggleHostExposureEntries } from '../../modem/host-exposure'
 
 export default class DisableHostExposureEntries extends Command {
   static args = {
@@ -11,8 +12,12 @@ export default class DisableHostExposureEntries extends Command {
     }),
   }
   static description = 'Disable a set of host exposure entries'
-  static examples = ['$ vodafone-station-cli host-exposure:disable -p PASSWORD [ENTRY NAME | [ENTRY NAME...]]']
+  static examples = [
+    '$ vodafone-station-cli host-exposure:disable -p PASSWORD [ENTRY NAME | [ENTRY NAME...]]',
+    '$ vodafone-station-cli host-exposure:disable -p PASSWORD --ip 192.168.100.1 [ENTRY NAME | [ENTRY NAME...]]',
+  ]
   static flags = {
+    ip: ipFlag(),
     password: Flags.string({
       char: 'p',
       description: 'router/modem password',
@@ -29,8 +34,12 @@ export default class DisableHostExposureEntries extends Command {
       this.exit()
     }
 
+    const discoveryOptions: DiscoveryOptions = {
+      ip: flags.ip,
+    }
+
     try {
-      await toggleHostExposureEntries(false, argv as string[], password!, this.logger)
+      await toggleHostExposureEntries(false, argv as string[], password!, this.logger, discoveryOptions)
     } catch (error) {
       this.error(error as Error, {message: 'Something went wrong.'})
     }

--- a/src/commands/host-exposure/enable.ts
+++ b/src/commands/host-exposure/enable.ts
@@ -1,8 +1,8 @@
-import { Flags } from '@oclif/core'
+import {Flags} from '@oclif/core'
 
-import Command, { ipFlag } from '../../base-command'
-import { DiscoveryOptions } from '../../modem/discovery'
-import { toggleHostExposureEntries } from '../../modem/host-exposure'
+import Command, {ipFlag} from '../../base-command'
+import {DiscoveryOptions} from '../../modem/discovery'
+import {toggleHostExposureEntries} from '../../modem/host-exposure'
 
 export default class EnableHostExposureEntries extends Command {
   static description = 'Enable a set of host exposure entries'
@@ -20,7 +20,7 @@ export default class EnableHostExposureEntries extends Command {
   static strict = false
 
   async run(): Promise<void> {
-    const { argv, flags } = await this.parse(EnableHostExposureEntries)
+    const {argv, flags} = await this.parse(EnableHostExposureEntries)
 
     const password = flags.password ?? process.env.VODAFONE_ROUTER_PASSWORD
     if (!password || password === '') {
@@ -35,7 +35,7 @@ export default class EnableHostExposureEntries extends Command {
     try {
       await toggleHostExposureEntries(true, argv as string[], password!, this.logger, discoveryOptions)
     } catch (error) {
-      this.error(error as Error, { message: 'Something went wrong.' })
+      this.error(error as Error, {message: 'Something went wrong.'})
     }
 
     this.exit()

--- a/src/commands/host-exposure/enable.ts
+++ b/src/commands/host-exposure/enable.ts
@@ -1,18 +1,17 @@
-import {Args, Flags} from '@oclif/core'
+import { Flags } from '@oclif/core'
 
-import Command from '../../base-command'
-import {toggleHostExposureEntries} from '../../modem/host-exposure'
+import Command, { ipFlag } from '../../base-command'
+import { DiscoveryOptions } from '../../modem/discovery'
+import { toggleHostExposureEntries } from '../../modem/host-exposure'
 
 export default class EnableHostExposureEntries extends Command {
-  static args = {
-    entries: Args.string({
-      description: 'Host exposure entries to enable. Pass no names to enable every existing entry.',
-      required: false,
-    }),
-  }
   static description = 'Enable a set of host exposure entries'
-  static examples = ['$ vodafone-station-cli host-exposure:enable -p PASSWORD [ENTRY NAME | [ENTRY NAME...]]']
+  static examples = [
+    '$ vodafone-station-cli host-exposure:enable -p PASSWORD [ENTRY NAME | [ENTRY NAME...]]',
+    '$ vodafone-station-cli host-exposure:enable -p PASSWORD --ip 192.168.100.1 [ENTRY NAME | [ENTRY NAME...]]',
+  ]
   static flags = {
+    ip: ipFlag(),
     password: Flags.string({
       char: 'p',
       description: 'router/modem password',
@@ -21,7 +20,7 @@ export default class EnableHostExposureEntries extends Command {
   static strict = false
 
   async run(): Promise<void> {
-    const {argv, flags} = await this.parse(EnableHostExposureEntries)
+    const { argv, flags } = await this.parse(EnableHostExposureEntries)
 
     const password = flags.password ?? process.env.VODAFONE_ROUTER_PASSWORD
     if (!password || password === '') {
@@ -29,10 +28,14 @@ export default class EnableHostExposureEntries extends Command {
       this.exit()
     }
 
+    const discoveryOptions: DiscoveryOptions = {
+      ip: flags.ip,
+    }
+
     try {
-      await toggleHostExposureEntries(true, argv as string[], password!, this.logger)
+      await toggleHostExposureEntries(true, argv as string[], password!, this.logger, discoveryOptions)
     } catch (error) {
-      this.error(error as Error, {message: 'Something went wrong.'})
+      this.error(error as Error, { message: 'Something went wrong.' })
     }
 
     this.exit()

--- a/src/commands/host-exposure/get.ts
+++ b/src/commands/host-exposure/get.ts
@@ -1,10 +1,10 @@
-import { Flags } from '@oclif/core'
+import {Flags} from '@oclif/core'
 
-import Command, { ipFlag } from '../../base-command'
-import { Log } from '../../logger'
-import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../../modem/discovery'
-import { modemFactory } from '../../modem/factory'
-import { HostExposureSettings } from '../../modem/modem'
+import Command, {ipFlag} from '../../base-command'
+import {Log} from '../../logger'
+import {discoverModemLocation, DiscoveryOptions, ModemDiscovery} from '../../modem/discovery'
+import {modemFactory} from '../../modem/factory'
+import {HostExposureSettings} from '../../modem/modem'
 
 export async function getHostExposureSettings(password: string, logger: Log, discoveryOptions?: DiscoveryOptions): Promise<HostExposureSettings> {
   const modemLocation = await discoverModemLocation(discoveryOptions)
@@ -32,7 +32,6 @@ export default class GetHostExposure extends Command {
 {JSON data}
 `,
   ];
-
   static flags = {
     ip: ipFlag(),
     password: Flags.string({

--- a/src/commands/host-exposure/get.ts
+++ b/src/commands/host-exposure/get.ts
@@ -1,13 +1,13 @@
-import {Flags} from '@oclif/core'
+import { Flags } from '@oclif/core'
 
-import Command from '../../base-command'
-import {Log} from '../../logger'
-import {discoverModemLocation, ModemDiscovery} from '../../modem/discovery'
-import {modemFactory} from '../../modem/factory'
-import {HostExposureSettings} from '../../modem/modem'
+import Command, { ipFlag } from '../../base-command'
+import { Log } from '../../logger'
+import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../../modem/discovery'
+import { modemFactory } from '../../modem/factory'
+import { HostExposureSettings } from '../../modem/modem'
 
-export async function getHostExposureSettings(password: string, logger: Log): Promise<HostExposureSettings> {
-  const modemLocation = await discoverModemLocation()
+export async function getHostExposureSettings(password: string, logger: Log, discoveryOptions?: DiscoveryOptions): Promise<HostExposureSettings> {
+  const modemLocation = await discoverModemLocation(discoveryOptions)
   const discoveredModem = await new ModemDiscovery(modemLocation, logger).discover()
   const modem = modemFactory(discoveredModem, logger)
   try {
@@ -23,14 +23,18 @@ export async function getHostExposureSettings(password: string, logger: Log): Pr
 }
 
 export default class GetHostExposure extends Command {
-  static description
-    = 'Get the current IPV6 host exposure settings';
+  static description = 'Get the current IPV6 host exposure settings';
   static examples = [
     `$ vodafone-station-cli host-exposure:get -p PASSWORD
 {JSON data}
 `,
+    `$ vodafone-station-cli host-exposure:get -p PASSWORD --ip 192.168.100.1
+{JSON data}
+`,
   ];
+
   static flags = {
+    ip: ipFlag(),
     password: Flags.string({
       char: 'p',
       description: 'router/modem password',
@@ -46,8 +50,12 @@ export default class GetHostExposure extends Command {
       this.exit()
     }
 
+    const discoveryOptions: DiscoveryOptions = {
+      ip: flags.ip,
+    }
+
     try {
-      const settings = await getHostExposureSettings(password!, this.logger)
+      const settings = await getHostExposureSettings(password!, this.logger, discoveryOptions)
       const settingsJSON = JSON.stringify(settings, undefined, 4)
       this.log(settingsJSON)
     } catch (error) {

--- a/src/commands/host-exposure/set.ts
+++ b/src/commands/host-exposure/set.ts
@@ -1,18 +1,19 @@
-import {Args, Flags} from '@oclif/core'
-import {readFile} from 'node:fs/promises'
+import { Args, Flags } from '@oclif/core'
+import { readFile } from 'node:fs/promises'
 
-import Command from '../../base-command'
-import {Log} from '../../logger'
-import {discoverModemLocation, ModemDiscovery} from '../../modem/discovery'
-import {modemFactory} from '../../modem/factory'
-import {HostExposureSettings} from '../../modem/modem'
+import Command, { ipFlag } from '../../base-command'
+import { Log } from '../../logger'
+import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../../modem/discovery'
+import { modemFactory } from '../../modem/factory'
+import { HostExposureSettings } from '../../modem/modem'
 
 export async function setHostExposureSettings(
   settings: HostExposureSettings,
   password: string,
   logger: Log,
+  discoveryOptions?: DiscoveryOptions,
 ): Promise<HostExposureSettings> {
-  const modemLocation = await discoverModemLocation()
+  const modemLocation = await discoverModemLocation(discoveryOptions)
   const discoveredModem = await new ModemDiscovery(modemLocation, logger).discover()
   const modem = modemFactory(discoveredModem, logger)
   try {
@@ -35,8 +36,12 @@ export default class SetHostExposure extends Command {
     }),
   }
   static description = 'Set the current IPV6 host exposure settings from a JSON file'
-  static examples = ['$ vodafone-station-cli host-exposure:set -p PASSWORD <FILE>']
+  static examples = [
+    '$ vodafone-station-cli host-exposure:set -p PASSWORD <FILE>',
+    '$ vodafone-station-cli host-exposure:set -p PASSWORD --ip 192.168.100.1 <FILE>',
+  ]
   static flags = {
+    ip: ipFlag(),
     password: Flags.string({
       char: 'p',
       description: 'router/modem password',
@@ -52,10 +57,14 @@ export default class SetHostExposure extends Command {
       this.exit()
     }
 
+    const discoveryOptions: DiscoveryOptions = {
+      ip: flags.ip,
+    }
+
     try {
       const newSettingsJSON = await readFile(args.file, {encoding: 'utf8'})
       const newSettings = JSON.parse(newSettingsJSON) as HostExposureSettings
-      await setHostExposureSettings(newSettings, password!, this.logger)
+      await setHostExposureSettings(newSettings, password!, this.logger, discoveryOptions)
       this.log('New host exposure settings set.')
     } catch (error) {
       this.error(error as Error, {message: 'Something went wrong.'})

--- a/src/commands/host-exposure/set.ts
+++ b/src/commands/host-exposure/set.ts
@@ -1,11 +1,11 @@
-import { Args, Flags } from '@oclif/core'
-import { readFile } from 'node:fs/promises'
+import {Args, Flags} from '@oclif/core'
+import {readFile} from 'node:fs/promises'
 
-import Command, { ipFlag } from '../../base-command'
-import { Log } from '../../logger'
-import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../../modem/discovery'
-import { modemFactory } from '../../modem/factory'
-import { HostExposureSettings } from '../../modem/modem'
+import Command, {ipFlag} from '../../base-command'
+import {Log} from '../../logger'
+import {discoverModemLocation, DiscoveryOptions, ModemDiscovery} from '../../modem/discovery'
+import {modemFactory} from '../../modem/factory'
+import {HostExposureSettings} from '../../modem/modem'
 
 export async function setHostExposureSettings(
   settings: HostExposureSettings,

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -1,52 +1,49 @@
-import {Flags} from '@oclif/core'
+import { Flags } from '@oclif/core';
 
-import Command from '../base-command'
-import {discoverModemLocation, ModemDiscovery} from '../modem/discovery'
-import {modemFactory} from '../modem/factory'
+import Command, { ipFlag } from '../base-command';
+import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../modem/discovery';
+import { modemFactory } from '../modem/factory';
 
 export default class Restart extends Command {
-  static description
-    = 'Restart the router/modem'
+  static description = 'restart the modem/router';
   static examples = [
-    '$ vodafone-station-cli restart -p PASSWORD',
-  ]
+    '$ vodafone-station-cli restart',
+    '$ vodafone-station-cli restart --ip 192.168.100.1',
+  ];
+
   static flags = {
+    ip: ipFlag(),
     password: Flags.string({
       char: 'p',
       description: 'router/modem password',
     }),
   }
 
-  async restartRouter(password: string): Promise<unknown> {
-    const modemLocation = await discoverModemLocation()
-    const discoveredModem = await new ModemDiscovery(
-      modemLocation,
-      this.logger,
-    ).discover()
-    const modem = modemFactory(discoveredModem, this.logger)
-    try {
-      await modem.login(password)
-      const restart = await modem.restart()
-      return restart
-    } catch (error) {
-      this.log('Something went wrong.', error)
-      this.error(error as Error)
-    } finally {
-      await modem.logout()
-    }
-  }
-
   async run(): Promise<void> {
     const {flags} = await this.parse(Restart)
-
     const password = flags.password ?? process.env.VODAFONE_ROUTER_PASSWORD
     if (!password || password === '') {
       this.log('You must provide a password either using -p or by setting the environment variable VODAFONE_ROUTER_PASSWORD')
       this.exit()
     }
 
-    this.log('Restarting router... this could take some time...')
-    await this.restartRouter(password!)
+    const discoveryOptions: DiscoveryOptions = {
+      ip: flags.ip,
+    }
+
+    const modemLocation = await discoverModemLocation(discoveryOptions)
+    const discoveredModem = await new ModemDiscovery(modemLocation, this.logger).discover()
+    const modem = modemFactory(discoveredModem, this.logger)
+    try {
+      await modem.login(password!)
+      await modem.restart()
+      this.log('The modem has been restarted.')
+    } catch (error) {
+      this.log('Something went wrong.', error)
+    } finally {
+      await modem.logout()
+    }
+
     this.exit()
   }
 }

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -1,8 +1,8 @@
-import { Flags } from '@oclif/core';
+import {Flags} from '@oclif/core';
 
-import Command, { ipFlag } from '../base-command';
-import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from '../modem/discovery';
-import { modemFactory } from '../modem/factory';
+import Command, {ipFlag} from '../base-command';
+import {discoverModemLocation, DiscoveryOptions, ModemDiscovery} from '../modem/discovery';
+import {modemFactory} from '../modem/factory';
 
 export default class Restart extends Command {
   static description = 'restart the modem/router';
@@ -10,7 +10,6 @@ export default class Restart extends Command {
     '$ vodafone-station-cli restart',
     '$ vodafone-station-cli restart --ip 192.168.100.1',
   ];
-
   static flags = {
     ip: ipFlag(),
     password: Flags.string({

--- a/src/modem/discovery.test.ts
+++ b/src/modem/discovery.test.ts
@@ -86,12 +86,12 @@ describe('Discovery', () => {
         expect(result.ipAddress).toBe('192.168.100.1');
       });
 
-             it('should try multiple default IPs if first fails', async () => {
+      it('should try multiple default IPs if first fails', async () => {
          const mockResponse = {
            status: 200,
            request: { 
              host: '192.168.0.1',
-             protocol: 'http:' 
+             protocol: 'https:' 
            }
          };
 

--- a/src/modem/discovery.test.ts
+++ b/src/modem/discovery.test.ts
@@ -1,0 +1,276 @@
+import axios from 'axios';
+import { discoverModemLocation, ModemDiscovery } from './discovery';
+import { extractFirmwareVersion } from './tools/html-parser';
+
+// Mock axios
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock html-parser
+jest.mock('./tools/html-parser');
+const mockedExtractFirmwareVersion = extractFirmwareVersion as jest.MockedFunction<typeof extractFirmwareVersion>;
+
+describe('Discovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.VODAFONE_ROUTER_IP;
+  });
+
+  describe('discoverModemLocation', () => {
+    describe('with IP parameter', () => {
+      it('should use provided IP address and return modem location', async () => {
+        const mockResponse = {
+          status: 200,
+          request: { 
+            host: '192.168.1.100',
+            protocol: 'http:' 
+          }
+        };
+        mockedAxios.head = jest.fn().mockResolvedValue(mockResponse);
+
+        const result = await discoverModemLocation({ ip: '192.168.1.100' });
+
+        expect(mockedAxios.head).toHaveBeenCalledWith('http://192.168.1.100');
+        expect(result).toEqual({
+          ipAddress: '192.168.1.100',
+          protocol: 'http',
+        });
+      });
+
+      it('should try both HTTP and HTTPS for provided IP', async () => {
+        const mockResponse = {
+          status: 200,
+          request: { 
+            host: '192.168.1.100',
+            protocol: 'https:' 
+          }
+        };
+        mockedAxios.head = jest.fn()
+          .mockRejectedValueOnce(new Error('HTTP failed'))
+          .mockResolvedValueOnce(mockResponse);
+
+        const result = await discoverModemLocation({ ip: '192.168.1.100' });
+
+        expect(mockedAxios.head).toHaveBeenCalledTimes(2);
+        expect(mockedAxios.head).toHaveBeenNthCalledWith(1, 'http://192.168.1.100');
+        expect(mockedAxios.head).toHaveBeenNthCalledWith(2, 'https://192.168.1.100');
+        expect(result).toEqual({
+          ipAddress: '192.168.1.100',
+          protocol: 'https',
+        });
+      });
+
+      it('should throw error if both HTTP and HTTPS fail with provided IP', async () => {
+        mockedAxios.head = jest.fn().mockRejectedValue(new Error('Connection failed'));
+
+        await expect(discoverModemLocation({ ip: '192.168.1.100' }))
+          .rejects.toThrow('Could not find a router/modem under the known addresses.');
+      });
+    });
+
+    describe('without IP parameter (default behavior)', () => {
+      it('should try default IPs when no IP provided', async () => {
+        const mockResponse = {
+          status: 200,
+          request: { 
+            host: '192.168.100.1',
+            protocol: 'http:' 
+          }
+        };
+        mockedAxios.head = jest.fn().mockResolvedValue(mockResponse);
+
+        const result = await discoverModemLocation();
+
+        // Should try first default IP
+        expect(mockedAxios.head).toHaveBeenCalledWith('http://192.168.100.1');
+        expect(result.ipAddress).toBe('192.168.100.1');
+      });
+
+             it('should try multiple default IPs if first fails', async () => {
+         const mockResponse = {
+           status: 200,
+           request: { 
+             host: '192.168.0.1',
+             protocol: 'http:' 
+           }
+         };
+
+         mockedAxios.head = jest.fn()
+           .mockRejectedValueOnce(new Error('Failed'))  // 192.168.100.1 HTTP
+           .mockRejectedValueOnce(new Error('Failed'))  // 192.168.100.1 HTTPS
+           .mockRejectedValueOnce(new Error('Failed'))  // 192.168.0.1 HTTP
+           .mockResolvedValueOnce(mockResponse);        // 192.168.0.1 HTTPS
+
+         const result = await discoverModemLocation();
+
+         expect(mockedAxios.head).toHaveBeenCalledTimes(4);
+         expect(mockedAxios.head).toHaveBeenNthCalledWith(1, 'http://192.168.100.1');
+         expect(mockedAxios.head).toHaveBeenNthCalledWith(2, 'https://192.168.100.1');
+         expect(mockedAxios.head).toHaveBeenNthCalledWith(3, 'http://192.168.0.1');
+         expect(mockedAxios.head).toHaveBeenNthCalledWith(4, 'https://192.168.0.1');
+         expect(result.ipAddress).toBe('192.168.0.1');
+         expect(result.protocol).toBe('https');
+       });
+    });
+
+    describe('protocol detection', () => {
+      it('should correctly extract protocol without colon', async () => {
+        const mockResponse = {
+          status: 200,
+          request: { 
+            host: '192.168.1.100',
+            protocol: 'https:' // Protocol with colon as returned by axios
+          }
+        };
+        mockedAxios.head = jest.fn().mockResolvedValue(mockResponse);
+
+        const result = await discoverModemLocation({ ip: '192.168.1.100' });
+
+        expect(result.protocol).toBe('https'); // Should be without colon
+      });
+    });
+  });
+
+  describe('ModemDiscovery', () => {
+    const mockLogger = {
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    const mockModemLocation = {
+      ipAddress: '192.168.1.1',
+      protocol: 'http' as const,
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('discover', () => {
+      it('should successfully discover Technicolor modem', async () => {
+        const mockTechnicolorResponse = {
+          data: {
+            error: 'ok',
+            data: {
+              firmwareversion: '20.3.c.0317',
+            },
+          },
+        };
+        mockedAxios.get = jest.fn()
+          .mockRejectedValueOnce(new Error('Arris failed')) // tryArris fails
+          .mockResolvedValueOnce(mockTechnicolorResponse);   // tryTechnicolor succeeds
+
+        const discovery = new ModemDiscovery(mockModemLocation, mockLogger as any);
+        const result = await discovery.discover();
+
+        expect(result).toEqual({
+          deviceType: 'Technicolor',
+          firmwareVersion: '20.3.c.0317',
+          ipAddress: '192.168.1.1',
+          protocol: 'http',
+        });
+      });
+
+      it('should successfully discover Arris modem', async () => {
+        const mockArrisResponse = {
+          data: '<html>some firmware version data</html>',
+        };
+
+        mockedExtractFirmwareVersion.mockReturnValue('AR01.03.045.12_042321_711.PC20.1');
+
+        mockedAxios.get = jest.fn()
+          .mockResolvedValueOnce(mockArrisResponse)         // tryArris succeeds
+          .mockRejectedValueOnce(new Error('Technicolor failed')); // tryTechnicolor fails
+
+        const discovery = new ModemDiscovery(mockModemLocation, mockLogger as any);
+        const result = await discovery.discover();
+
+        expect(result).toEqual({
+          deviceType: 'Arris',
+          firmwareVersion: 'AR01.03.045.12_042321_711.PC20.1',
+          ipAddress: '192.168.1.1',
+          protocol: 'http',
+        });
+      });
+
+      it('should throw error when both modem types fail', async () => {
+        mockedAxios.get = jest.fn().mockRejectedValue(new Error('Connection failed'));
+
+        const discovery = new ModemDiscovery(mockModemLocation, mockLogger as any);
+        
+        await expect(discovery.discover()).rejects.toThrow();
+      });
+    });
+
+    describe('tryTechnicolor', () => {
+      it('should make correct API call for Technicolor', async () => {
+        const mockResponse = {
+          data: {
+            error: 'ok',
+            data: {
+              firmwareversion: '20.3.c.0317',
+            },
+          },
+        };
+        mockedAxios.get = jest.fn().mockResolvedValue(mockResponse);
+
+        const discovery = new ModemDiscovery(mockModemLocation, mockLogger as any);
+        const result = await discovery.tryTechnicolor();
+
+        expect(mockedAxios.get).toHaveBeenCalledWith('http://192.168.1.1/api/v1/login_conf');
+        expect(result.deviceType).toBe('Technicolor');
+        expect(result.firmwareVersion).toBe('20.3.c.0317');
+      });
+
+      it('should throw error for invalid Technicolor response', async () => {
+        const mockResponse = {
+          data: {
+            error: 'failed',
+          },
+        };
+        mockedAxios.get = jest.fn().mockResolvedValue(mockResponse);
+
+        const discovery = new ModemDiscovery(mockModemLocation, mockLogger as any);
+        
+        await expect(discovery.tryTechnicolor()).rejects.toThrow('Could not determine modem type');
+      });
+    });
+
+    describe('tryArris', () => {
+      it('should make correct API call for Arris', async () => {
+        const mockResponse = {
+          data: '<html>firmware data</html>',
+        };
+
+        mockedExtractFirmwareVersion.mockReturnValue('AR01.03.045.12_042321_711.PC20.1');
+
+        mockedAxios.get = jest.fn().mockResolvedValue(mockResponse);
+
+        const discovery = new ModemDiscovery(mockModemLocation, mockLogger as any);
+        const result = await discovery.tryArris();
+
+        expect(mockedAxios.get).toHaveBeenCalledWith('http://192.168.1.1/index.php', {
+          headers: {
+            Accept: 'text/html,application/xhtml+xml,application/xml',
+          },
+        });
+        expect(result.deviceType).toBe('Arris');
+      });
+
+      it('should throw error when firmware version cannot be extracted', async () => {
+        const mockResponse = {
+          data: '<html>no firmware data</html>',
+        };
+
+        mockedExtractFirmwareVersion.mockReturnValue(undefined);
+
+        mockedAxios.get = jest.fn().mockResolvedValue(mockResponse);
+
+        const discovery = new ModemDiscovery(mockModemLocation, mockLogger as any);
+        
+        await expect(discovery.tryArris()).rejects.toThrow('Unable to parse firmware version.');
+      });
+    });
+  });
+}); 

--- a/src/modem/discovery.ts
+++ b/src/modem/discovery.ts
@@ -1,8 +1,8 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, {AxiosResponse} from 'axios';
 
-import { Log } from '../logger';
-import { TechnicolorConfiguration } from './technicolor-modem';
-import { extractFirmwareVersion } from './tools/html-parser';
+import {Log} from '../logger';
+import {TechnicolorConfiguration} from './technicolor-modem';
+import {extractFirmwareVersion} from './tools/html-parser';
 
 // Default IP addresses - can be overridden via CLI flags or environment variables
 const DEFAULT_BRIDGED_MODEM_IP = '192.168.100.1';
@@ -21,10 +21,11 @@ export interface DiscoveryOptions {
 
 export async function discoverModemLocation(options: DiscoveryOptions = {}): Promise<ModemLocation> {
   let defaultIps = [DEFAULT_BRIDGED_MODEM_IP, DEFAULT_ROUTER_IP];
-    // If specific IP is provided, only try that IP
+  // If specific IP is provided, only try that IP
   if (options.ip) {
     defaultIps = [options.ip];
   }
+
   try {
     const headRequests = [];
     for (const ip of defaultIps) {

--- a/src/modem/discovery.ts
+++ b/src/modem/discovery.ts
@@ -29,8 +29,10 @@ export async function discoverModemLocation(options: DiscoveryOptions = {}): Pro
   try {
     const headRequests = [];
     for (const ip of defaultIps) {
-      headRequests.push(axios.head(`http://${ip}`));
-      headRequests.push(axios.head(`https://${ip}`));
+      headRequests.push(
+        axios.head(`http://${ip}`),
+        axios.head(`https://${ip}`),
+      );
     }
 
     const results = await Promise.allSettled(headRequests);

--- a/src/modem/host-exposure.ts
+++ b/src/modem/host-exposure.ts
@@ -1,9 +1,9 @@
-import {Log} from '../logger'
-import {discoverModemLocation, ModemDiscovery} from './discovery'
-import {modemFactory} from './factory'
+import { Log } from '../logger'
+import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from './discovery'
+import { modemFactory } from './factory'
 
-export async function toggleHostExposureEntries(toggle: boolean, entries: string[], password: string, logger: Log): Promise<void> {
-  const modemLocation = await discoverModemLocation()
+export async function toggleHostExposureEntries(toggle: boolean, entries: string[], password: string, logger: Log, discoveryOptions?: DiscoveryOptions): Promise<void> {
+  const modemLocation = await discoverModemLocation(discoveryOptions)
   const discoveredModem = await new ModemDiscovery(modemLocation, logger).discover()
   const modem = modemFactory(discoveredModem, logger)
   try {

--- a/src/modem/host-exposure.ts
+++ b/src/modem/host-exposure.ts
@@ -1,6 +1,6 @@
-import { Log } from '../logger'
-import { discoverModemLocation, DiscoveryOptions, ModemDiscovery } from './discovery'
-import { modemFactory } from './factory'
+import {Log} from '../logger'
+import {discoverModemLocation, DiscoveryOptions, ModemDiscovery} from './discovery'
+import {modemFactory} from './factory'
 
 export async function toggleHostExposureEntries(toggle: boolean, entries: string[], password: string, logger: Log, discoveryOptions?: DiscoveryOptions): Promise<void> {
   const modemLocation = await discoverModemLocation(discoveryOptions)


### PR DESCRIPTION
# PR: Add IP Flag Support 

## Overview
This PR introduces support for an IP flag across commands, allowing users to specify the IP address of the modem/router. 

## Changes
- Added IP flag support to host exposure commands.
- Integrated IP flag into the diagnose command for enhanced functionality.