### PR TITLE
fix: improve modem location logging and remove debug statements

### DIFF
--- a/src/commands/discover.ts
+++ b/src/commands/discover.ts
@@ -20,7 +20,7 @@ export default class Discover extends Command {
       }
 
       const modemLocation = await discoverModemLocation(discoveryOptions);
-      this.log(`Possibly found modem under the following location: ${JSON.stringify(modemLocation)}`);
+      this.log(`Possibly found modem under the following location: ${modemLocation.protocol}://${modemLocation.ipAddress}`);
       const modem = new ModemDiscovery(modemLocation, this.logger);
       const discoveredModem = await modem.discover();
       this.log(`Discovered modem: ${JSON.stringify(discoveredModem)}`);

--- a/src/modem/discovery.ts
+++ b/src/modem/discovery.ts
@@ -38,8 +38,6 @@ export async function discoverModemLocation(options: DiscoveryOptions = {}): Pro
     const results = await Promise.allSettled(headRequests);
     const maybeResult = results.find(result => result.status === 'fulfilled') as undefined | {value: AxiosResponse};
     if (maybeResult?.value.request?.host) {
-      console.warn('maybeResult');
-      console.warn(maybeResult);
       return {
         ipAddress: maybeResult?.value.request?.host,
         protocol: maybeResult?.value.request?.protocol.replace(':', '') as Protocol,


### PR DESCRIPTION
This pull request refines the modem discovery process by improving logging for better clarity and removing unnecessary debug statements. Below are the key changes grouped by their themes:

### Improvements to Logging:

* Updated the log message in `src/commands/discover.ts` to display the modem location using its protocol and IP address instead of a JSON string. This makes the output more readable and user-friendly.

### Code Cleanup:

* Removed redundant debug `console.warn` statements from `src/modem/discovery.ts` to clean up the code and avoid unnecessary console output.