### PR TITLE
fix: tslib packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-v1.5.1
+v1.5.2
 ---
 - **🚨 Critical Fix**: Fixed "Cannot find module 'tslib'" runtime error by moving `tslib` from devDependencies to dependencies
-- **Documentation updates**: Updated README.md with latest dependency versions
 
-**Note**: This release fixes a critical packaging issue that prevented the CLI from running after npm installation due to missing TypeScript runtime helpers.
+
+**Full Changelog**: https://github.com/totev/vodafone-station-cli/compare/v1.5.1...v1.5.2
+
+v1.5.1
+---
+- **Documentation updates**: Updated README.md with latest dependency versions  
 
 **Full Changelog**: https://github.com/totev/vodafone-station-cli/compare/v1.5.0...v1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 v1.5.1
 ---
-- **Documentation updates**: Updated README.md with latest dependency versions  
+- **🚨 Critical Fix**: Fixed "Cannot find module 'tslib'" runtime error by moving `tslib` from devDependencies to dependencies
+- **Documentation updates**: Updated README.md with latest dependency versions
+
+**Note**: This release fixes a critical packaging issue that prevented the CLI from running after npm installation due to missing TypeScript runtime helpers.
 
 **Full Changelog**: https://github.com/totev/vodafone-station-cli/compare/v1.5.0...v1.5.1
 

--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ $ npm install -g vodafone-station-cli
 $ vodafone-station-cli COMMAND
 running command...
 $ vodafone-station-cli (--version)
-vodafone-station-cli/1.5.0 darwin-arm64 node-v24.2.0
+vodafone-station-cli/1.5.2 darwin-arm64 node-v24.2.0
 $ vodafone-station-cli --help [COMMAND]
 USAGE
   $ vodafone-station-cli COMMAND
@@ -594,7 +594,7 @@ EXAMPLES
   $ vodafone-station-cli diagnose --ip 192.168.100.1
 ```
 
-_See code: [src/commands/diagnose.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/diagnose.ts)_
+_See code: [src/commands/diagnose.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.1/src/commands/diagnose.ts)_
 
 ## `vodafone-station-cli discover`
 
@@ -616,7 +616,7 @@ EXAMPLES
   $ vodafone-station-cli discover --ip 192.168.100.1
 ```
 
-_See code: [src/commands/discover.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/discover.ts)_
+_See code: [src/commands/discover.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.1/src/commands/discover.ts)_
 
 ## `vodafone-station-cli docsis`
 
@@ -643,7 +643,7 @@ EXAMPLES
   {JSON data}
 ```
 
-_See code: [src/commands/docsis.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/docsis.ts)_
+_See code: [src/commands/docsis.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.1/src/commands/docsis.ts)_
 
 ## `vodafone-station-cli help [COMMAND]`
 
@@ -689,7 +689,7 @@ EXAMPLES
   $ vodafone-station-cli host-exposure:disable -p PASSWORD --ip 192.168.100.1 [ENTRY NAME | [ENTRY NAME...]]
 ```
 
-_See code: [src/commands/host-exposure/disable.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/host-exposure/disable.ts)_
+_See code: [src/commands/host-exposure/disable.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.1/src/commands/host-exposure/disable.ts)_
 
 ## `vodafone-station-cli host-exposure enable`
 
@@ -712,7 +712,7 @@ EXAMPLES
   $ vodafone-station-cli host-exposure:enable -p PASSWORD --ip 192.168.100.1 [ENTRY NAME | [ENTRY NAME...]]
 ```
 
-_See code: [src/commands/host-exposure/enable.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/host-exposure/enable.ts)_
+_See code: [src/commands/host-exposure/enable.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.1/src/commands/host-exposure/enable.ts)_
 
 ## `vodafone-station-cli host-exposure get`
 
@@ -737,7 +737,7 @@ EXAMPLES
   {JSON data}
 ```
 
-_See code: [src/commands/host-exposure/get.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/host-exposure/get.ts)_
+_See code: [src/commands/host-exposure/get.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.1/src/commands/host-exposure/get.ts)_
 
 ## `vodafone-station-cli host-exposure set FILE`
 
@@ -763,7 +763,7 @@ EXAMPLES
   $ vodafone-station-cli host-exposure:set -p PASSWORD --ip 192.168.100.1 <FILE>
 ```
 
-_See code: [src/commands/host-exposure/set.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/host-exposure/set.ts)_
+_See code: [src/commands/host-exposure/set.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.1/src/commands/host-exposure/set.ts)_
 
 ## `vodafone-station-cli plugins`
 
@@ -1076,5 +1076,5 @@ EXAMPLES
   $ vodafone-station-cli restart --ip 192.168.100.1
 ```
 
-_See code: [src/commands/restart.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.0/src/commands/restart.ts)_
+_See code: [src/commands/restart.ts](https://github.com/totev/vodafone-station-cli/blob/v1.5.1/src/commands/restart.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vodafone-station-cli",
   "description": "Access your Vodafone Station from the comfort of the command line.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": "Dobroslav Totev",
   "bin": {
     "vodafone-station-cli": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "dotenv": "^16.5.0",
     "http-cookie-agent": "^7.0.1",
     "sjcl": "1.0.8",
-    "tough-cookie": "^5.1.2"
+    "tough-cookie": "^5.1.2",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@oclif/prettier-config": "^0.2.1",
@@ -56,7 +57,6 @@
     "shx": "^0.4.0",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
-    "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.0"
   },


### PR DESCRIPTION
This pull request addresses a critical runtime issue in the `vodafone-station-cli` package and updates the documentation to reflect the new version. The most important changes include fixing a missing dependency, updating the version number, and modifying references in the documentation.

### Critical Fixes:
* Moved `tslib` from `devDependencies` to `dependencies` in `package.json` to resolve the "Cannot find module 'tslib'" runtime error. This ensures the CLI runs correctly after installation. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L40-R41) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L59)

### Version Updates:
* Updated the package version from `1.5.1` to `1.5.2` in `package.json` to reflect the new release.

Issue ref: https://github.com/totev/vodafone-station-cli/issues/262
