### PR TITLE
fix: enhance logging with colorized messages for modem diagnostics

### DIFF
--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -2,7 +2,7 @@ import {Flags} from '@oclif/core';
 
 import Command, {ipFlag} from '../base-command';
 import {DiscoveryOptions} from '../modem/discovery';
-import DocsisDiagnose from '../modem/docsis-diagnose';
+import DocsisDiagnose, {colorize} from '../modem/docsis-diagnose';
 import {TablePrinter} from '../modem/printer';
 import {webDiagnoseLink} from '../modem/web-diagnose';
 import {getDocsisStatus} from './docsis';
@@ -46,7 +46,7 @@ export default class Diagnose extends Command {
       this.log(tablePrinter.print())
 
       if (diagnoser.hasDeviations()) {
-        this.logger.warn('Docsis connection connection quality deviation found!')
+        this.log(colorize('yellow', 'Warning: Docsis connection quality deviation found!'));
       }
 
       if (flags.web) {

--- a/src/commands/docsis.test.ts
+++ b/src/commands/docsis.test.ts
@@ -10,6 +10,7 @@ const mockLogger = {
   debug: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
+  log: jest.fn(),
 };
 
 const mockModem = {

--- a/src/commands/docsis.ts
+++ b/src/commands/docsis.ts
@@ -4,6 +4,7 @@ import {promises as fsp} from 'node:fs'
 import Command, {ipFlag} from '../base-command'
 import {Log} from '../logger'
 import {discoverModemLocation, DiscoveryOptions, ModemDiscovery} from '../modem/discovery'
+import {colorize} from '../modem/docsis-diagnose'
 import {modemFactory} from '../modem/factory'
 import {DocsisStatus} from '../modem/modem'
 import {webDiagnoseLink} from '../modem/web-diagnose'
@@ -17,7 +18,7 @@ export async function getDocsisStatus(password: string, logger: Log, discoveryOp
     const docsisData = await modem.docsis()
     return docsisData
   } catch (error) {
-    logger.warn('Could not fetch docsis status from modem.')
+    logger.log(colorize('red', 'Could not fetch docsis status from modem.'))
     logger.error(error as Error)
     throw error
   } finally {

--- a/src/modem/discovery.ts
+++ b/src/modem/discovery.ts
@@ -78,7 +78,7 @@ export class ModemDiscovery {
 
       return maybeModem;
     } catch (error) {
-      this.logger.warn('Could not find a router/modem under the known addresses');
+      this.logger.log('yellow', 'Could not find a router/modem under the known addresses');
       throw error;
     }
   }

--- a/src/modem/host-exposure.ts
+++ b/src/modem/host-exposure.ts
@@ -1,5 +1,6 @@
 import {Log} from '../logger'
 import {discoverModemLocation, DiscoveryOptions, ModemDiscovery} from './discovery'
+import {colorize} from './docsis-diagnose'
 import {modemFactory} from './factory'
 
 export async function toggleHostExposureEntries(toggle: boolean, entries: string[], password: string, logger: Log, discoveryOptions?: DiscoveryOptions): Promise<void> {
@@ -18,7 +19,7 @@ export async function toggleHostExposureEntries(toggle: boolean, entries: string
     for (const name of names) {
       const index = settings.hosts.findIndex(host => host.serviceName === name)
       if (index === -1) {
-        logger.warn(`Entry with the name '${name}' does not exist.`)
+        logger.log(colorize('yellow', `Entry with the name '${name}' does not exist.`))
       } else {
         settings.hosts[index].enabled = toggle
       }


### PR DESCRIPTION
Swap `oclif`'s warn logging command for a log one with coloured output. This way the stack trace is not always printed.