### PR TITLE
Fix firmware detection for AR01.05.063.15_082825_735.PC20.20.VF

### DIFF
--- a/src/modem/discovery.test.ts
+++ b/src/modem/discovery.test.ts
@@ -194,6 +194,28 @@ describe('Discovery', () => {
         });
       });
 
+      it('should successfully discover Arris modem with swVer pattern', async () => {
+        const mockArrisResponse = {
+          data: '<html><script>var _ga = {}; _ga.swVer = "AR01.05.063.15_082825_735.PC20.20.VF";</script></html>',
+        };
+
+        mockedExtractFirmwareVersion.mockReturnValue('AR01.05.063.15_082825_735.PC20.20.VF');
+
+        mockedAxios.get = jest.fn()
+          .mockResolvedValueOnce(mockArrisResponse)         // tryArris succeeds
+          .mockRejectedValueOnce(new Error('Technicolor failed')); // tryTechnicolor fails
+
+        const discovery = new ModemDiscovery(mockModemLocation, mockLogger as any);
+        const result = await discovery.discover();
+
+        expect(result).toEqual({
+          deviceType: 'Arris',
+          firmwareVersion: 'AR01.05.063.15_082825_735.PC20.20.VF',
+          ipAddress: '192.168.1.1',
+          protocol: 'http',
+        });
+      });
+
       it('should throw error when both modem types fail', async () => {
         mockedAxios.get = jest.fn().mockRejectedValue(new Error('Connection failed'));
 

--- a/src/modem/discovery.ts
+++ b/src/modem/discovery.ts
@@ -29,6 +29,8 @@ export async function discoverModemLocation(options: DiscoveryOptions = {}): Pro
 
   debug(`Probing for modem at IPs: ${defaultIps.join(', ')}`);
 
+  // Try HEAD requests first
+  let maybeResult: undefined | {value: AxiosResponse} = undefined;
   try {
     const headRequests = [];
     for (const ip of defaultIps) {
@@ -39,19 +41,39 @@ export async function discoverModemLocation(options: DiscoveryOptions = {}): Pro
     }
 
     const results = await Promise.allSettled(headRequests);
-    const maybeResult = results.find(result => result.status === 'fulfilled') as undefined | {value: AxiosResponse};
-    if (maybeResult?.value.request?.host) {
-      return {
-        ipAddress: maybeResult?.value.request?.host,
-        protocol: maybeResult?.value.request?.protocol.replace(':', '') as Protocol,
-      };
+    maybeResult = results.find(result => result.status === 'fulfilled') as undefined | {value: AxiosResponse};
+  } catch (error) {
+    // HEAD failed, will try GET below
+  }
+
+  // If HEAD failed, try GET requests to /index.php
+  if (!maybeResult) {
+    const getRequests = [];
+    for (const ip of defaultIps) {
+      getRequests.push(
+        axios.get(`http://${ip}/index.php`, {
+          headers: {Accept: 'text/html,application/xhtml+xml,application/xml'},
+          validateStatus: () => true, // Accept any status code
+        }),
+        axios.get(`https://${ip}/index.php`, {
+          headers: {Accept: 'text/html,application/xhtml+xml,application/xml'},
+          validateStatus: () => true,
+        }),
+      );
     }
 
-    throw new Error('Could not find a router/modem under the known addresses.');
-  } catch (error) {
-    console.error('Could not find a router/modem under the known addresses.');
-    throw error;
+    const results = await Promise.allSettled(getRequests);
+    maybeResult = results.find(result => result.status === 'fulfilled') as undefined | {value: AxiosResponse};
   }
+
+  if (maybeResult?.value?.request?.host) {
+    return {
+      ipAddress: maybeResult?.value?.request?.host,
+      protocol: maybeResult?.value?.request?.protocol.replace(':', '') as Protocol,
+    };
+  }
+
+  throw new Error('Could not find a router/modem under the known addresses.');
 }
 
 export type Protocol = 'http' | 'https';

--- a/src/modem/tools/html-parser.ts
+++ b/src/modem/tools/html-parser.ts
@@ -4,7 +4,7 @@ const nonceMatcher = /var csp_nonce = "(?<nonce>.*?)";/gm
 const ivMatcher = /var myIv = ["|'](?<iv>.*?)["|'];/gm
 const saltMatcher = /var mySalt = ["|'](?<salt>.*?)["|'];/gm
 const sessionIdMatcher = /var currentSessionId = ["|'](?<sessionId>.*?)["|'];/gm
-const swVersionMatcher = /_ga.swVersion = ["|'](?<swVersion>.*?)["|'];/gm
+const swVersionMatcher = /_ga\.swVersion = ["|'](?<swVersion>.*?)["|'](?:;|$)|_ga\.swVer = ["|'](?<swVersion2>.*?)["|'](?:;|$)/gm
 
 export interface CryptoVars {
   iv: string;
@@ -24,7 +24,11 @@ export function extractCryptoVars(html: string): CryptoVars {
 }
 
 export function extractFirmwareVersion(html: string): string | undefined {
-  return swVersionMatcher.exec(html)?.groups?.swVersion
+  const match = swVersionMatcher.exec(html)
+  if (!match?.groups?.swVersion && !match?.groups?.swVersion2) {
+    return undefined
+  }
+  return match?.groups?.swVersion || match?.groups?.swVersion2
 }
 
 export function extractDocsisStatus(


### PR DESCRIPTION
Fix firmware detection for AR01.05.063.15_082825_735.PC20.20.VF

- Support both _ga.swVersion and _ga.swVer patterns in html-parser.ts
- Add fallback to GET requests when HEAD requests fail in discovery.ts
- Add test case for swVer firmware pattern

FYI: This code was generated with opencode and Qwen3.5:9b locally and tested manually with my router